### PR TITLE
feat: entities added

### DIFF
--- a/back/src/modules/chat/entities/chat.entity.ts
+++ b/back/src/modules/chat/entities/chat.entity.ts
@@ -1,1 +1,0 @@
-export class Chat {}

--- a/back/src/modules/chat/entities/chatRoom.entities.ts
+++ b/back/src/modules/chat/entities/chatRoom.entities.ts
@@ -1,0 +1,27 @@
+import { User } from 'src/modules/users/entities/user.entity';
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Message } from './message.entity';
+
+@Entity()
+export class ChatRoom {
+  @PrimaryGeneratedColumn()
+  id: string;
+
+  @Column()
+  name: string;
+
+  @ManyToOne(() => User, (user) => user.chatRooms)
+  creator: User;
+
+  @OneToMany(() => Message, (message) => message.chatRoom)
+  messages: Message[];
+
+  @Column('simple-array')
+  participants: number[];
+}

--- a/back/src/modules/chat/entities/message.entity.ts
+++ b/back/src/modules/chat/entities/message.entity.ts
@@ -1,0 +1,30 @@
+import { User } from 'src/modules/users/entities/user.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ChatRoom } from './chatRoom.entities';
+
+@Entity()
+export class Message {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('text')
+  text: string;
+
+  @Column({ nullable: true })
+  photoUrl?: string;
+
+  @ManyToOne(() => User, (user) => user.messages)
+  sender: User;
+
+  @ManyToOne(() => ChatRoom, (chatRoom) => chatRoom.messages)
+  chatRoom: ChatRoom;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/back/src/modules/users/entities/user.entity.ts
+++ b/back/src/modules/users/entities/user.entity.ts
@@ -1,1 +1,24 @@
-export class User {}
+import { ChatRoom } from 'src/modules/chat/entities/chatRoom.entities';
+import { Message } from 'src/modules/chat/entities/message.entity';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  username: string;
+
+  @Column()
+  password: string;
+
+  @Column({ nullable: true })
+  profilePicture?: string;
+
+  @OneToMany(() => Message, (message) => message.sender)
+  messages: Message[];
+
+  @OneToMany(() => ChatRoom, (chatRoom) => chatRoom.creator)
+  chatRooms: ChatRoom[];
+}


### PR DESCRIPTION
### Add Entities for Real-Time Chat Application

- **User Entity**: Represents users with fields for `username`, `password`, and `profilePictureUrl`. Establishes a one-to-many relationship with `Message` and `ChatRoom`.
- **Message Entity**: Represents messages with fields for `text`, `photoUrl`, and relationships with `User` (sender) and `ChatRoom`.
- **ChatRoom Entity**: Represents chat rooms with fields for `name` and `participants`. Establishes a one-to-many relationship with `Message` and a many-to-one relationship with `User` (creator).

